### PR TITLE
Allowing anonymous keys to be used in sort

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -60,7 +60,7 @@ module.exports = (function() {
       ssl: false
     },
     supportsType: function(type) {
-      !!~"decimal".split(" ").indexOf(type);
+      return !!~"decimal".split(" ").indexOf(type);
     },
     /*************************************************************************/
     /* Public Methods for Sails/Waterline Adapter Compatibility              */

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -59,7 +59,9 @@ module.exports = (function() {
       schema: true,
       ssl: false
     },
-
+    supportsType: function(type) {
+      !!~"decimal".split(" ").indexOf(type);
+    },
     /*************************************************************************/
     /* Public Methods for Sails/Waterline Adapter Compatibility              */
     /*************************************************************************/

--- a/lib/query.js
+++ b/lib/query.js
@@ -638,9 +638,17 @@ Query.prototype.sort = function(table, options) {
   this._query += ' ORDER BY ';
   Object.keys(options).forEach(function(key) {
     var direction = options[key] === 1 ? 'ASC' : 'DESC';
-    self._query += utils.escapeName(table) + '.' + utils.escapeName(key) + ' ' + direction + ', ';
-  });
+    // modifying it, check if it is in the schema, if it is not, use it directly
+    var sortKey;
+    if ( key in self._schema ) {
+      sortKey = utils.escapeName(table) + '.' + utils.escapeName(key);
+      // this is a recognized key, so use the previous logic
+    } else {
+      sortKey = key;
+    }
 
+    self._query += sortKey + ' ' + direction + ', ';
+  });
   // Remove trailing comma
   this._query = this._query.slice(0, -2);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -292,7 +292,7 @@ utils.sqlTypeCast = function(type) {
     case 'bytea':
       return 'BYTEA';
     case 'decimal':
-      return 'DECIMAL';
+      return 'DECIMAL(11,7)';
     default:
       console.error("Unregistered type given: " + type);
       return "TEXT";

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -291,7 +291,8 @@ utils.sqlTypeCast = function(type) {
     case 'binary':
     case 'bytea':
       return 'BYTEA';
-
+    case 'decimal':
+      return 'DECIMAL';
     default:
       console.error("Unregistered type given: " + type);
       return "TEXT";

--- a/test/unit/query.sort.js
+++ b/test/unit/query.sort.js
@@ -75,12 +75,13 @@ describe('query', function() {
 
       var schema = {
         test: {
-          name: { type: 'text' }
+          name: { type: 'text' },
+          age: {type: 'number'}
         }
       };
 
-      var query = new Query({ name: { type: 'text' }}, schema).find('test', criteria);
-      var sql = 'SELECT "test"."name" FROM "test" WHERE LOWER("test"."name") = $1 ' +
+      var query = new Query(schema.test, schema).find('test', criteria);
+      var sql = 'SELECT "test"."name", "test"."age" FROM "test" WHERE LOWER("test"."name") = $1 ' +
                 'ORDER BY "test"."name" ASC, "test"."age" ASC';
 
       query.query.should.eql(sql);
@@ -101,16 +102,41 @@ describe('query', function() {
 
       var schema = {
         test: {
+          name: { type: 'text' },
+          age: {type: 'number'}
+        }
+      };
+
+      var query = new Query(schema.test, schema).find('test', criteria);
+      var sql = 'SELECT "test"."name", "test"."age" FROM "test" WHERE LOWER("test"."name") = $1 ' +
+                'ORDER BY "test"."name" ASC, "test"."age" DESC';
+
+      query.query.should.eql(sql);
+    });
+
+    it('should unknown keys, for example, functions to be used for sorting', function(){
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        sort: {
+          name: 1,
+          "znear(homelat,homelng,1,1)": 1
+        }
+      };
+
+      var schema = {
+        test: {
           name: { type: 'text' }
         }
       };
 
       var query = new Query({ name: { type: 'text' }}, schema).find('test', criteria);
       var sql = 'SELECT "test"."name" FROM "test" WHERE LOWER("test"."name") = $1 ' +
-                'ORDER BY "test"."name" ASC, "test"."age" DESC';
+                'ORDER BY "test"."name" ASC, znear(homelat,homelng,1,1) ASC';
 
       query.query.should.eql(sql);
-    });
-
+    })
   });
 });


### PR DESCRIPTION
This change checks the key of sort option against schema instead of directly using them, and this will allow things like

```javascript
// given the model might look like {name:{type:"string"}, birthday:{type:"date"}}
model.find({}).sort({name:1, "datediff(birthday, current_date)":1});
```

and as for the supported type, it is related to a pull request I made against waterline, balderdashy/waterline#827, i do not know if it will get accepted, but if it does, this will allow each adapter to extend waterline better.